### PR TITLE
Add October 2025 Julia newsletter page

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,8 +1,9 @@
 format: jb-book
-root: pages/2025_09
+root: pages/2025_10
 parts:
 - caption: '2025'
   chapters:
+  - file: pages/2025_09
   - file: pages/2025_08
   - file: pages/2025_06
   - file: pages/2025_05

--- a/pages/2025_10.md
+++ b/pages/2025_10.md
@@ -1,0 +1,57 @@
+# Octobre 2025 
+
+Bonjour! 
+
+## Billets de blog et Articles
+
+- [Julia 1.12 Highlights](https://julialang.org/blog/2025/10/julia-1.12-highlights/)
+- [This month in Julia world - 2025-09](https://discourse.julialang.org/t/this-month-in-julia-world-2025-09/133110)
+- [JuliaHub October 2025 Newsletter - Agentic AI for Model-Based Engineering, Dr Viral Shah at Simulation World, and Julia 1.12 Released](https://juliahub.com/blog/october-2025-newsletter)
+- [JOSS Papers in Julia](https://joss.theoj.org/papers/in/Julia)
+- [Claude Code sucks but is still useful: experiences maintaining Julia’s SciML scientific computing infrastructure](https://www.stochasticlifestyle.com/claude-code-in-scientific-computing-experiences-maintaining-julias-sciml-infrastructure/)
+
+## Packages
+
+- [AdditionalDistributions.jl](https://github.com/Santymax98/AdditionalDistributions.jl): extend Distributions.jl.
+- [BGZFLib.jl](https://github.com/BioJulia/BGZFLib.jl): Read and write BGZF files.
+- [ClassicalOrthogonalPolynomials.jl](https://github.com/JuliaApproximation/ClassicalOrthogonalPolynomials.jl): classical orthogonal polynomials and expansions.
+- [DearDiary.jl](https://github.com/pebeto/DearDiary.jl): A lightweight but powerful machine learning experiment tracking tool for Julia.
+- [FieldViews.jl](https://github.com/MasonProtter/FieldViews.jl): access and manipulate views of selected fields of structs.
+- [FiniteDiffWENO5.jl](https://github.com/JuliaGeodynamics/FiniteDiffWENO5.jl): Advect fields using a finite difference WENO5 scheme on CPUs or GPUs.
+- [FourierContinuation.jl](https://github.com/vanmcmx/FourierContinuation.jl): Fourier continuation (FC) framework for high-order PDE solvers.
+- [Fugl.jl](https://github.com/ErikBuer/Fugl.jl): A functional GUI library written in Julia using OpenGL.
+- [LowLevelFEM.jl](https://github.com/perebalazs/LowLevelFEM.jl): finite element analysis with an engineering-first workflow.
+- [OSMGeocoder.jl](https://github.com/joshday/OSMGeocoder.jl): Geocoding via OpenStreetMap's Nominatim.
+- [PencilFlows.jl](https://github.com/subhk/PencilFlows.jl): solving fluid dynamics problems using spectral methods.
+- [PortfolioOptimisers.jl](https://github.com/dcelisgarza/PortfolioOptimisers.jl): Portfolio Optimisation library.
+- [MakieTypstEngine.jl](https://github.com/henrik-wolf/MakieTypstEngine.jl): Use typst strings in Makie!
+- [MCPRepl.jl](https://github.com/hexaeder/MCPRepl.jl): Expose your repl via MCP!
+- [PinCFlow.jl](https://github.com/Atmospheric-Dynamics-GUF/PinCFlow.jl): An idealized-atmospheric-flow solver coupled to the 3D transient gravity-wave model.
+- [PlutoSlides.jl](https://github.com/dmetivie/PlutoSlides.jl): Pluto notebooks looking like Beamer presentations or A Pluto slideshow!)
+- [RejectionSamplers.jl](https://github.com/QEDjl-project/RejectionSamplers.jl): Hardware-agnostic parallel distribution sampling for CPU and GPU.
+- [RepoPacker.jl](https://github.com/imohag9/RepoPacker.jl): tool designed to feed entire codebases into AI systems for analysis.
+- [SlepcWrap.jl](https://github.com/bmxam/SlepcWrap.jl): Parallel Julia wrapper for SLEPc.
+- [StructuralVibration.jl](https://github.com/maucejo/StructuralVibration.jl): generate vibration data for mechanical systems.
+- [SymbolicApproximators.jl](https://github.com/myersm0/SymbolicApproximators.jl): methods for symbolic time series discretization.
+- [TerminalPager.jl](https://github.com/ronisbr/TerminalPager.jl)
+- [TextAssociations.jl](https://github.com/atantos/TextAssociations.jl): Bringing Julia to the Digital Humanities and Social Sciences.
+- [Tractography.jl](https://github.com/rveltz/Tractography.jl): Tractography algorithms.
+- [WaveSim.jl](https://github.com/cmey/WaveSim.jl): Wave propagation simulator.
+
+## Vidéos
+
+- [State of Julia | Hafner, Fischer](https://www.youtube.com/watch?v=-60gOIGoD7U)
+- [JuliaCon Pittsburgh 2025](https://www.youtube.com/playlist?list=PLP8iPy9hna6SZOq4EH_nE_BFulBAKXkf1)
+- [JuliaCon Paris 2025](https://www.youtube.com/playlist?list=PLP8iPy9hna6TJMLEiZZiWAXlyGtOyJSL7)
+
+## Tutoriels, Documentation, Livres, Supports de cours...
+
+- [LuxRecurrentLayers.jl](https://github.com/MartinuzziFrancesco/LuxRecurrentLayers.jl) A comprehensive collection of 25+ recurrent neural network layers for Lux.jl.
+- [LLM Benchmark problems for SWE tasks in julia](https://github.com/JuliaBench/JuliaBench)
+- [Pratique du calcul scientifique - École nationale des ponts et chaussées](https://enpc-casc.github.io)
+
+
+
+[*Abonnez-vous à la liste Julia du CNRS*](https://listes.services.cnrs.fr/wws/subscribe/julia)
+
+[*Archives*](https://pnavaro.github.io/NouvellesJulia)


### PR DESCRIPTION
Created pages/2025_10.md with curated Julia news, packages, videos, and resources for October 2025. Updated _toc.yml to set 2025_10 as root and include 2025_09 in the table of contents.